### PR TITLE
Use the multistreamer amd64 image by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ postgresql:
   image: postgres:latest
 multistreamer:
   restart: always
-  image: jprjr/multistreamer:11.0.7-1
+  image: jprjr/multistreamer:11.0.7-1-amd64  # override with 11.0.7-1-armv6 if needed
   links:
    - redisio
    - postgresql


### PR DESCRIPTION
Right now `docker-compose up` fails because of the missing `11.0.7-1` tag. This makes it work by default on most systems.